### PR TITLE
Set default stale period in Redeemer

### DIFF
--- a/contracts/Redeemer.sol
+++ b/contracts/Redeemer.sol
@@ -23,6 +23,10 @@ contract Redeemer is Context, ReentrancyGuard {
     // Oracle => stalePeriod mapping
     mapping(address => uint256) public stalePeriod;
 
+    address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address private constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
     event UpdatedRedeemFee(uint256 previousRedeemFee, uint256 newRedeemFee);
     event UpdatedPriceTolerance(uint256 previousTolerance, uint256 newTolerance);
     event UpdatedStalePeriod(address indexed oracle, uint256 previousStalePeriod, uint256 newStalePeriod);
@@ -31,6 +35,12 @@ contract Redeemer is Context, ReentrancyGuard {
         require(_vusd != address(0), "vusd-address-is-zero");
         vusd = IVUSD(_vusd);
         vusdDecimals = IERC20Metadata(_vusd).decimals();
+
+        // set default stale periods for DAI, USDC, USDT, oracles
+        ITreasury _treasury = ITreasury(IVUSD(_vusd).treasury());
+        stalePeriod[_treasury.oracles(DAI)] = 1 hours;
+        stalePeriod[_treasury.oracles(USDC)] = 24 hours;
+        stalePeriod[_treasury.oracles(USDT)] = 24 hours;
     }
 
     modifier onlyGovernor() {


### PR DESCRIPTION
Default stale period of Redeemer should be same as Minter.  Governor wont need to set default manually after deployment of new version of Redeemer.